### PR TITLE
Don't cast $crop to bool

### DIFF
--- a/grayscale.php
+++ b/grayscale.php
@@ -43,7 +43,7 @@ function grayscale_init() {
 // provide a new function to declare grayscaled images
 function grayscale_add_image_size( $name, $width = 0, $height = 0, $crop = false, $grayscale = false ) {
 	global $_wp_additional_image_sizes;
-	$_wp_additional_image_sizes[$name] = array( 'width' => absint( $width ), 'height' => absint( $height ), 'crop' => (bool) $crop, 'grayscale' => (bool) $grayscale );
+	$_wp_additional_image_sizes[$name] = array( 'width' => absint( $width ), 'height' => absint( $height ), 'crop' => $crop, 'grayscale' => (bool) $grayscale );
 }
 
 // hook to call the image generation function if needed


### PR DESCRIPTION
Since WordPress 3.9 you can optionally pass an array that will determine from where the crop occurs. Casting to a boolean prevents this functionality from being used with your plugin.

https://github.com/WordPress/WordPress/blob/master/wp-includes/media.php#L473
